### PR TITLE
Updated package.json to reflect the modules included in scripts/postinstall.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,10 @@
     "src/servers/*"
   ],
   "devDependencies": {
+    "@babel/register": "^7.4.4",
     "better-docs": "^1.1.3",
+    "chalk": "^2.4.2",
+    "child-process-promise": "^2.2.1",
     "cross-env": "^5.2.0",
     "husky": "^1.3.1",
     "jsdoc": "^3.5.5",
@@ -59,7 +62,9 @@
     "jsdoc-to-markdown": "^4.0.1",
     "lerna": "^3.4.0",
     "lint-staged": "^7.3.0",
+    "minimist": "^1.2.0",
     "mocha": "^6.1.4",
+    "multispinner": "^0.2.1",
     "patch-package": "^6.0.2",
     "puppeteer": "^1.15.0"
   },


### PR DESCRIPTION
To avoid going through NPM (since it has the version all wonky and I wanted to make sure I was using the right code), I decided to install all of Skypager straight from GitHub, but ran into some missing dependencies. It turned out that `postinstall.js` had multiple `require()`s for new packages, so I forked Skypager and installed them with `--save-dev`, and here's the `package.json` from that.